### PR TITLE
Required Menu Bundle

### DIFF
--- a/Doctrine/Phpcr/MenuBlock.php
+++ b/Doctrine/Phpcr/MenuBlock.php
@@ -49,16 +49,16 @@ class MenuBlock extends AbstractBlock
      *
      * Set to null to remove the reference.
      *
-     * @param NodeInterface $menuNode A mapped menu node.
+     * @param NodeInterface|null $menuNode A mapped menu node.
      *
      * @return MenuBlock $this
      */
     public function setMenuNode($menuNode = null)
     {
-        if ($menuNode instanceof NodeInterface) {
+        if (null === $menuNode || $menuNode instanceof NodeInterface) {
             $this->menuNode = $menuNode;
         } else {
-            $this->menuNode = null;
+            throw new \InvalidArgumentException('$menuNode must be an instane of NodeInterface');
         }
 
         return $this;

--- a/Doctrine/Phpcr/MenuBlock.php
+++ b/Doctrine/Phpcr/MenuBlock.php
@@ -53,9 +53,13 @@ class MenuBlock extends AbstractBlock
      *
      * @return MenuBlock $this
      */
-    public function setMenuNode(NodeInterface $menuNode = null)
+    public function setMenuNode($menuNode = null)
     {
-        $this->menuNode = $menuNode;
+        if ($menuNode instanceof NodeInterface) {
+            $this->menuNode = $menuNode;
+        } else {
+            $this->menuNode = null;
+        }
 
         return $this;
     }

--- a/Tests/Functional/Block/MenuBlockServiceTest.php
+++ b/Tests/Functional/Block/MenuBlockServiceTest.php
@@ -66,4 +66,16 @@ class MenuBlockServiceTest extends \PHPUnit_Framework_TestCase
         $menuBlockService = new MenuBlockService('test-service', $templatingMock, $blockRendererMock, $blockContextManagerMock);
         $menuBlockService->execute($menuBlockContext);
     }
+
+    public function testSetMenuNode()
+    {
+        $menuBlock = new MenuBlock();
+        $this->assertAttributeEmpty('menuNode', $menuBlock);
+
+        $menuBlock->setMenuNode($this->getMock('Knp\Menu\NodeInterface'));
+        $this->assertAttributeInstanceOf('Knp\Menu\NodeInterface', 'menuNode', $menuBlock);
+
+        $menuBlock->setMenuNode(null);
+        $this->assertAttributeSame(null, 'menuNode', $menuBlock);
+    }
 }


### PR DESCRIPTION
I'm playing with symfony-cmf and I'm only using the BlockBundle (without the MenuBundle).

I got this exception

    [Doctrine\Common\Proxy\Exception\UnexpectedValueException]                                                                                    
      The type hint of parameter "menuNode" in method "setMenuNode" in class "Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\MenuBlock" is invalid. 

https://github.com/symfony-cmf/BlockBundle/blob/master/Doctrine/Phpcr/MenuBlock.php
The MenuBlock has a dependency to  Knp\Menu\NodeInterface

So I would change the require-dev dependency to require to solve the issue.

The other possibility is to require the sonata-menu-bundle instead of menu-bundle.