### PR TITLE
migrate errorElement

### DIFF
--- a/Block/ActionBlockService.php
+++ b/Block/ActionBlockService.php
@@ -11,11 +11,8 @@
 
 namespace Symfony\Cmf\Bundle\BlockBundle\Block;
 
-use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Validator\ErrorElement;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Model\BlockInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\ActionBlock;
 use Symfony\Component\HttpFoundation\Request;
@@ -54,22 +51,6 @@ class ActionBlockService extends BaseBlockService
     public function setRequest(Request $request = null)
     {
         $this->request = $request;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function buildEditForm(FormMapper $form, BlockInterface $block)
-    {
-        throw new \RuntimeException('Not used at the moment, editing using a frontend or backend UI could be changed here');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
-    {
-        throw new \RuntimeException('Not used at the moment, validation for editing using a frontend or backend UI could be changed here');
     }
 
     /**

--- a/Block/ContainerBlockService.php
+++ b/Block/ContainerBlockService.php
@@ -11,13 +11,10 @@
 
 namespace Symfony\Cmf\Bundle\BlockBundle\Block;
 
-use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Validator\ErrorElement;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\BlockRendererInterface;
 use Sonata\BlockBundle\Block\BlockServiceInterface;
-use Sonata\BlockBundle\Model\BlockInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -50,22 +47,6 @@ class ContainerBlockService extends BaseBlockService implements BlockServiceInte
         if ($template) {
             $this->template = $template;
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function buildEditForm(FormMapper $form, BlockInterface $block)
-    {
-        throw new \RuntimeException('Not used at the moment, editing using a frontend or backend UI could be changed here');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
-    {
-        throw new \RuntimeException('Not used at the moment, validation for editing using a frontend or backend UI could be changed here');
     }
 
     /**

--- a/Block/MenuBlockService.php
+++ b/Block/MenuBlockService.php
@@ -11,13 +11,9 @@
 
 namespace Symfony\Cmf\Bundle\BlockBundle\Block;
 
-use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Validator\ErrorElement;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\BlockServiceInterface;
-use Sonata\BlockBundle\Model\BlockInterface;
-
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -37,22 +33,6 @@ class MenuBlockService extends BaseBlockService implements BlockServiceInterface
         if ($template) {
             $this->template = $template;
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function buildEditForm(FormMapper $form, BlockInterface $block)
-    {
-        throw new \RuntimeException('Not used at the moment, editing using a frontend or backend UI could be changed here');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
-    {
-        throw new \RuntimeException('Not used at the moment, validation for editing using a frontend or backend UI could be changed here');
     }
 
     /**

--- a/Block/ReferenceBlockService.php
+++ b/Block/ReferenceBlockService.php
@@ -11,15 +11,11 @@
 
 namespace Symfony\Cmf\Bundle\BlockBundle\Block;
 
-use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Validator\ErrorElement;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\BlockContextManagerInterface;
 use Sonata\BlockBundle\Block\BlockRendererInterface;
 use Sonata\BlockBundle\Block\BlockServiceInterface;
-use Sonata\BlockBundle\Model\BlockInterface;
-
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -40,22 +36,6 @@ class ReferenceBlockService extends BaseBlockService implements BlockServiceInte
         parent::__construct($name, $templating);
         $this->blockRenderer = $blockRenderer;
         $this->blockContextManager = $blockContextManager;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function buildEditForm(FormMapper $form, BlockInterface $block)
-    {
-        throw new \RuntimeException('Not used at the moment, editing using a frontend or backend UI could be changed here');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
-    {
-        throw new \RuntimeException('Not used at the moment, validation for editing using a frontend or backend UI could be changed here');
     }
 
     /**

--- a/Block/SimpleBlockService.php
+++ b/Block/SimpleBlockService.php
@@ -11,12 +11,9 @@
 
 namespace Symfony\Cmf\Bundle\BlockBundle\Block;
 
-use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Validator\ErrorElement;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\BlockServiceInterface;
-use Sonata\BlockBundle\Model\BlockInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -30,22 +27,6 @@ class SimpleBlockService extends BaseBlockService implements BlockServiceInterfa
             $this->template = $template;
         }
         parent::__construct($name, $templating);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function buildEditForm(FormMapper $form, BlockInterface $block)
-    {
-        throw new \RuntimeException('Not used at the moment, editing using a frontend or backend UI could be changed here');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
-    {
-        throw new \RuntimeException('Not used at the moment, validation for editing using a frontend or backend UI could be changed here');
     }
 
     /**

--- a/Block/StringBlockService.php
+++ b/Block/StringBlockService.php
@@ -11,12 +11,9 @@
 
 namespace Symfony\Cmf\Bundle\BlockBundle\Block;
 
-use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Validator\ErrorElement;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\BlockServiceInterface;
-use Sonata\BlockBundle\Model\BlockInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -31,22 +28,6 @@ class StringBlockService extends BaseBlockService implements BlockServiceInterfa
         if ($template) {
             $this->template = $template;
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function buildEditForm(FormMapper $form, BlockInterface $block)
-    {
-        throw new \RuntimeException('Not used at the moment, editing using a frontend or backend UI could be changed here');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
-    {
-        throw new \RuntimeException('Not used at the moment, validation for editing using a frontend or backend UI could be changed here');
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/framework-bundle": "~2.3",
         "doctrine/phpcr-bundle" :"~1.0",
         "doctrine/phpcr-odm": "~1.0",
-        "sonata-project/block-bundle": ">=2.2.8,<=2.2.13",
+        "sonata-project/block-bundle": "2.3.*",
         "symfony-cmf/core-bundle": "~1.0"
     },
     "conflict": {


### PR DESCRIPTION
This PR requires sonata/core-bundle >=2.3.1 (see https://github.com/sonata-project/SonataBlockBundle/commit/06fac2531ac872ea94a650a345331e14c4da9eb0)

These methods do not need to be overriden as there are now implemented in the parent abstract class.

I'm not sure about the composer version update...

Related to https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/330