### PR TITLE
Relax sonata/block-bundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/framework-bundle": "~2.3",
         "doctrine/phpcr-bundle" :"~1.0",
         "doctrine/phpcr-odm": "~1.0",
-        "sonata-project/block-bundle": "2.3.*",
+        "sonata-project/block-bundle": "2.3.*|2.4.*",
         "symfony-cmf/core-bundle": "~1.0"
     },
     "conflict": {


### PR DESCRIPTION
Allow to install ``sonata/block-bundle`` 2.3 / 2.4