### PR TITLE
fixed route pattern for SSI cache

### DIFF
--- a/Resources/config/routing/cache.xml
+++ b/Resources/config/routing/cache.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="cmf_block_cache_ssi" path="/symfony-cmf/block/cache/ssi/{_token}/{block_id}">
+    <route id="cmf_block_cache_ssi" path="/symfony-cmf/block/cache/ssi/{_token}">
         <default key="_controller">cmf.block.cache.ssi:cacheAction</default>
     </route>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

block_id removed from pattern slug as expected in request data and breaks default requirement for slug parameter "[^/]++"