### PR TITLE
Allow SonataBlockBundle 2.2 and improve test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,35 +13,35 @@ sudo: false
 cache:
   directories:
     - $HOME/.composer/cache/files
-
+ 
 env:
-  - SYMFONY_VERSION=2.7.* SYMFONY_DEPRECATIONS_HELPER=weak
+  global:
+    - SYMFONY_DEPRECATIONS_HELPER=1457
 
 matrix:
   include:
+    - php: 5.6
+      env: DEPS=dev
     - php: 5.3
-      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
+      env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
-      env: SYMFONY_VERSION=2.3.* SYMFONY_DEPRECATIONS_HELPER=weak
+      env: SYMFONY_VERSION=2.3.*
     - php: 5.6
-      env: SYMFONY_VERSION=2.8.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.0.*
-  allow_failures:
-    - env: SYMFONY_VERSION=2.8.*
-    - env: SYMFONY_VERSION=3.0.*
+      env: SYMFONY_VERSION=2.7.*
   fast_finish: true
 
 before_install:
+  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
+  - phpenv config-rm xdebug.ini || true
   - composer self-update
-  - sh -c 'if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;'
-  - composer require symfony/symfony:${SYMFONY_VERSION} --no-update
+  - if [ "$DEPS" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
   
-install: composer update $COMPOSER_FLAGS --prefer-dist
+install: composer update --prefer-dist $COMPOSER_FLAGS
 
 before_script: vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh
 
-script: phpunit --coverage-text
+script: phpunit
 
 notifications:
   irc: "irc.freenode.org#symfony-cmf"

--- a/composer.json
+++ b/composer.json
@@ -11,21 +11,20 @@
             "homepage": "https://github.com/symfony-cmf/BlockBundle/contributors"
         }
     ],
-    "minimum-stability": "dev",
     "require": {
         "php": "^5.3.9|^7.0",
         "symfony/framework-bundle": "^2.3",
         "doctrine/phpcr-bundle" :"^1.0",
         "doctrine/phpcr-odm": "^1.0",
-        "sonata-project/block-bundle": ">=2.3,<2.5",
+        "sonata-project/block-bundle": ">=2.2.12,<2.5",
         "symfony-cmf/core-bundle": "^1.1"
     },
     "conflict": {
         "symfony/framework-bundle": ">=2.3.0,<2.3.2"
     },
     "require-dev": {
-        "symfony-cmf/testing": "^1.2.6",
-        "symfony-cmf/menu-bundle": "^1.1",
+        "symfony-cmf/testing": "^1.3@RC",
+        "symfony-cmf/menu-bundle": "^1.1|^2.0",
         "sonata-project/doctrine-phpcr-admin-bundle": "^1.1",
         "symfony-cmf/tree-browser-bundle": "^1.0.0-RC1",
         "sonata-project/cache-bundle": ">=2.1.3,<2.1.6",


### PR DESCRIPTION
Allowing 2.2 is required to support SonataAdminBundle 2.3 (and SonataAdminBundle 2.3 is required by most other CMF bundles). Without this, CMF 1.3 can't be installed with sonata admin.